### PR TITLE
added last step to click on lead created

### DIFF
--- a/config/test_cases/create_lead.json
+++ b/config/test_cases/create_lead.json
@@ -131,12 +131,25 @@
         {
             "id": "navigate_to_leads",
             "action": "navigate",
-            "url": "https://betterhearing--staging.sandbox.lightning.force.com/lightning/o/Lead/list"
+            "url": "https://betterhearing--staging.sandbox.lightning.force.com/lightning/o/Lead/list",
+            "optional": true
+        },
+        {
+            "id": "wait_for_leads_page_load",
+            "action": "wait",
+            "time": 5000,
+            "description": "Wait for page to fully load"
         },
         {
             "id": "click_first_lead",
             "action": "click",
-            "selector": "a[data-refid='recordId']"
+            "selector": "a[data-refid='recordId'][title='${FIRST_NAME} ${LAST_NAME}']"
+        },
+        {
+            "id": "wait_for_lead_to_load",
+            "action": "wait",
+            "time": 1000,
+            "description": "Wait for lead page to fully load"
         }
     ]
 }

--- a/src/test_runner.py
+++ b/src/test_runner.py
@@ -85,6 +85,8 @@ class TestRunner:
                     self.tester.page.wait_for_load_state('domcontentloaded')
                     
                 elif action == 'click':
+                    if 'selector' in step:
+                        step['selector'] = self._replace_variables(step['selector'], variables)
                     self.logger.debug(f"Clicking element: {step['selector']}")
                     try:
                         timeout = 5000 if is_optional else self.config.get('element_timeout', 30000)


### PR DESCRIPTION
Update the selector in create_lead.json to target leads by full name.

Current:

"selector": "a[data-refid='recordId']"
Update to:

"selector": "a[data-refid='recordId'][title='${FIRST_NAME} ${LAST_NAME}']"
This will make the test more precise by targeting the specific lead that was just created.

and fixes #9 